### PR TITLE
Major code refactor with rationale

### DIFF
--- a/lib/hello_crawler.ex
+++ b/lib/hello_crawler.ex
@@ -32,7 +32,7 @@ defmodule HelloCrawler do
              |> handle_response(url)
              |> Enum.reject(&Enum.member?(paths, to_string(&1)))
              |> Enum.map(&(Task.async(fn -> get_links(&1, paths, context) end)))
-             |> Enum.map(&Task.await/1)
+             |> Enum.map(&Task.await(&1, :infinity))
              |> List.flatten]
     else
       [url]

--- a/lib/hello_crawler.ex
+++ b/lib/hello_crawler.ex
@@ -1,55 +1,62 @@
 defmodule HelloCrawler do
 
-  @default_max_depth 3
+  @default_depth 3
   @default_headers []
   @default_options [follow_redirect: true]
 
   def get_links(url, opts \\ []) do
     url = URI.parse(url)
+
     context = %{
-      max_depth: Keyword.get(opts, :max_depth, @default_max_depth),
+      depth: Keyword.get(opts, :depth, @default_depth),
       headers: Keyword.get(opts, :headers, @default_headers),
       options: Keyword.get(opts, :options, @default_options),
       host: url.host
     }
-    get_links(url, [], context)
+
+    url
+    |> get_links([], context)
     |> Enum.map(&to_string/1)
     |> Enum.uniq
   end
 
-  defp get_links(url, path, context) do
-    if continue_crawl?(path, context) and crawlable_url?(url, context) do
-      url
-      |> to_string
-      |> HTTPoison.get(context.headers, context.options)
-      |> handle_response(path, url, context)
+  defp get_links(url, paths, context) do
+    paths = [url | paths]
+    context = Map.put(context, :depth, context.depth - 1)
+
+    if continue_crawl?(url, context) do
+      IO.puts("Crawling \"#{url}\"...")
+      [url | url
+             |> to_string
+             |> HTTPoison.get(context.headers, context.options)
+             |> handle_response(url)
+             |> Enum.reject(&Enum.member?(paths, to_string(&1)))
+             |> Enum.map(&(Task.async(fn -> get_links(&1, paths, context) end)))
+             |> Enum.map(&Task.await/1)
+             |> List.flatten]
     else
       [url]
     end
   end
 
-  defp continue_crawl?(path, %{max_depth: max_depth}) when length(path) > max_depth, do: false
-  defp continue_crawl?(_, _), do: true
+  defp continue_crawl?(%{host: host}, %{depth: depth, host: initial}), do: depth >= 0 and host == initial
 
-  defp crawlable_url?(%{host: host}, %{host: initial}) when host == initial, do: true
-  defp crawlable_url?(_, _), do: false
-
-  defp handle_response({:ok, %{body: body}}, path, url, context) do
-    IO.puts("Crawling \"#{url}\"...")
-    path = [url | path]
-    [url | body
-           |> Floki.find("a")
-           |> Floki.attribute("href")
-           |> Enum.map(&URI.merge(url, &1))
-           |> Enum.map(&to_string/1)
-           |> Enum.reject(&Enum.member?(path, &1))
-           |> Enum.map(&(Task.async(fn -> get_links(URI.parse(&1), [&1 | path], context) end)))
-           |> Enum.map(&Task.await/1)
-           |> List.flatten]
+  defp handle_response({:ok, %{body: body }}, url) do
+    with {:ok, document} <- Floki.parse_document(body) do
+      document
+      |> Floki.find("a")
+      |> Floki.attribute("href")
+      |> Enum.map(&URI.merge(url, &1))
+      |> Enum.uniq
+    else
+      _ -> 
+        IO.puts("FAIL: \"#{url}\" (reason: invalid HTML)")
+        []
+    end
   end
 
-  defp handle_response(_response, _path, url) do
-    [url]
+  defp handle_response({_, %{ reason: reason }}, url) do
+    IO.puts("FAIL: \"#{url}\" (reason: #{to_string(reason)})")
+    []
   end
-
 end

--- a/lib/hello_crawler.ex
+++ b/lib/hello_crawler.ex
@@ -21,7 +21,7 @@ defmodule HelloCrawler do
   end
 
   defp get_links(url, paths, context) do
-    paths = [url | paths]
+    paths = [to_string(url) | paths]
     context = Map.put(context, :depth, context.depth - 1)
 
     if continue_crawl?(url, context) do

--- a/lib/hello_crawler.ex
+++ b/lib/hello_crawler.ex
@@ -25,13 +25,15 @@ defmodule HelloCrawler do
     
     if continue_crawl?(url, context) do
       IO.puts("Crawling \"#{url}\"...")
+      paths = [to_string(url) | paths]
+
       targets = url
              |> to_string
              |> HTTPoison.get(context.headers, context.options)
              |> handle_response(url)
              |> Enum.reject(&Enum.member?(paths, to_string(&1)))
 
-      paths = [url | paths] ++ (targets |> Enum.map(&to_string/1))
+      paths = paths ++ (targets |> Enum.map(&to_string/1))
 
       [url | targets
              |> Enum.map(&(Task.async(fn -> get_links(&1, paths, context) end)))

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule HelloCrawler.Mixfile do
     [
       app: :hello_crawler,
       version: "0.1.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.6",
       start_permanent: Mix.env == :prod,
       deps: deps()
     ]
@@ -22,8 +22,8 @@ defmodule HelloCrawler.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:httpoison, "~> 0.13"},
-      {:floki, "~> 0.18.0"}
+      {:httpoison, "~> 2.2.1"},
+      {:floki, "~> 0.36.0"}
     ]
   end
 end


### PR DESCRIPTION
Hi, hope all is well. I rather apologize for bringing a 7 year old project to your attention, but my professor has found your work quite worthy of including it in the syllabus; I honor your work

Anyway, there are some design issues and behavior issues in general. I have took my time to fix them.

This PR is an overall refactor, but I believe I have solid reasons without any bias

Here are the reasons

## `max_depth` behavior

I have changed this to depth and this tracks the recursion depth instead. `paths` has different semantics now

## `path` variable name

`path` was misleading as it was a list of `URI`s instead. Without changing the name, it has been refactored to plural

## `url` processing on L15

Has been changed to use `url` and pipes, to follow the rest of the code style

## `handle_response` refactor

I particularly found this function to be assigned with too many responsibilities

Thus, I have implemented the following changes

### Signature change

Signature has changed from `response, path, url, context` to `response, url`, in order to signify that the function is only responsible for handling the response and origin url

### Remove call to `get_response`

`handle_response` is now at the end of the call hierarchy. This reduces confusion of reader because previously it was two functions recursively calling each other

### Remove crawling log

This function does not make the request. It is logical that `get_links` logs this intead.

Or the loggin message can be changed to something like "finding links from ..."

### Use modern `Floki.parse_document` api

`Floki.find` without parsing it first is deprecated. Using a with clause, we can check if the HTML is malformed as well

### Move unique

Unique link processing has been moved from `get_links/2` to `handle_response`. This makes the crawler not visit the same link twice if two identical links exist in the same document (e.g. /home.html)

### New return semantics

`handle_response` now returns unique links found in a document. In any error, return empty list

### Error logging

Basic error logging for failing crawls have been implemented

## `continue_crawl` and `crawlable_url` simplification

`continue_crawl` already had too general semantics that it would make sense to unify the two functions, as the two functions were rather simple. Additionally, both functions have been reduced to a single match statement in order to improve developer experience (removed the when clauses)

## `get_links` semantics change

This is the biggest change now that `get_links` has new responsibility that has been moved from `handle_response`.

### Filtering previously visited urls

Is now the responsibility of `get_links`, and as such `paths` is updated here along with context

### Filtering refactor

There was an `URI.parse(to_string(url))` redundancy that was present in the previous filtering code

```elixir
|> Enum.map(&to_string/1)
|> Enum.reject(&Enum.member?(path, &1))
|> Enum.map(&(Task.async(fn -> get_links(URI.parse(&1), [&1 | path], context) end)))
```

Has been changed so that only to_string is called when checking for member.

```elixir
|> Enum.reject(&Enum.member?(paths, to_string(&1)))
```

### Diamond problem partial improvement

If every page has link A, B, C, D, then the following issue happens (starting with A):

```txt
-> A
A -> B -> C -> D
       -> D -> C
  -> C -> B -> D
       -> D -> B
  -> D -> B -> C
       -> C -> B
```

= 16 requests

However, if we expand path early on by appending all links instead of the current url:

```txt
-> A
A -> B
  -> C
  -> D
```

= 4 requests

Saving a lot of requests

### Direct recursion

Refactored `get_links -> handle_response -> get_links` recursion so that get_links calls itself. I believe this is significantly easier to read

---

Overall, I have not included any changes that complicate the code or adds more features, I have fixed/improved the existing design.

If you have differing opinions about the design let me know and I'll amend the PR